### PR TITLE
build: move devDependencies into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,7 @@
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "vitest": "^2.1.5",
-    "zod": "^3.23.8"
-  },
-  "devDependencies": {
+    "zod": "^3.23.8",
     "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",


### PR DESCRIPTION
The @types packages were incorrectly placed in devDependencies when they should be in dependencies for proper type checking during runtime.